### PR TITLE
The following signatures were invalid: KEYEXPIRED 1473479811

### DIFF
--- a/tasks/repository.yml
+++ b/tasks/repository.yml
@@ -2,8 +2,8 @@
 ---
 - name: add public key
   apt_key:
-    id: 76D78F0500D026C4
-    url: https://d2t3ff60b2tol4.cloudfront.net/services@insynchq.com.gpg.key
+    id: A684470CACCAF35C
+    keyserver: keyserver.ubuntu.com
     state: present
   tags:
     - insync-repository-public-key


### PR DESCRIPTION
https://forums.insynchq.com/t/new-insync-version-1-3-11/7178

Make sure to run this (once) before provisioning:

```
sudo apt-key remove ACCAF35C
```
